### PR TITLE
Update @types/react-native to match react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@types/enzyme": "^2.8.0",
     "@types/jest": "^19.2.3",
     "@types/react": "^15.0.23",
-    "@types/react-native": "^0.43.9",
+    "@types/react-native": "^0.44",
     "@types/react-test-renderer": "^15.5.0",
     "babel-jest": "19.0.0",
     "babel-preset-react-native": "1.9.1",


### PR DESCRIPTION
This fixes compile errors with TypeScript 2.6+